### PR TITLE
Added black_box annotations to naive-vs-fast benchmark.

### DIFF
--- a/benches/naive-vs-fast.rs
+++ b/benches/naive-vs-fast.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use std::hint::black_box;
+
 use fast_matmul::{fast::Param, *};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -17,11 +19,11 @@ fn bench(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("fast", size), size, |b, size| {
             let mut C = Matrix::new(*size, *size);
-            b.iter(|| fast::matmul(*size, *size, *size, &A, &B, &mut C, param))
+            b.iter(|| black_box(fast::matmul(*size, *size, *size, black_box(&A), black_box(&B), black_box(&mut C), param)))
         });
         group.bench_with_input(BenchmarkId::new("naive", size), size, |b, size| {
             let mut C = Matrix::new(*size, *size);
-            b.iter(|| naive::matmul(*size, *size, *size, &A, &B, &mut C))
+            b.iter(|| black_box(naive::matmul(*size, *size, *size, black_box(&A), black_box(&B), black_box(&mut C))))
         });
     }
     group.finish();


### PR DESCRIPTION
It's important to make sure the compiler can't use information and operand generation in its optimization of the matrix multiplication.